### PR TITLE
feat: create contextual menu and add the option to copy the command to install or deploy all selected apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,14 @@ You can open the Command Palette (`Ctrl+Shift+P`) and run the commands.
 
 - **Create a VTEX IO diagram**: This command will create a diagram of your VTEX IO app dependencies in the current workspace or the selected folder, to generate the diagram the extension read the `manifest.json` file in the main folders only
 
-This command helps you to visualize the dependencies of your VTEX IO app in a diagram, you can see the dependencies between the apps and the blocks
+This command helps you to visualize the dependencies of your VTEX IO app in a diagram, you can see the dependencies between the apps and the blocks.
+
+### Contextual menu
+
+You can use the contextual menu in the editor to run the next commands:
+
+- **Create a VTEX IO diagram**: Create a diagram of your VTEX IO app in the current workspace or the selected directory.
+- **Copy install VTEX apps command** and **Copy deploy VTEX apps command**: This commands allows you to select directories or use the current workspace to generate a list of apps to install based on the current version specified in the `manifest.json` file. It then copies the install command to the clipboard for easy pasting and execution in your terminal.
 
 ### How to install the extension?
 

--- a/package.json
+++ b/package.json
@@ -36,14 +36,49 @@
         "title": "Create a VTEX IO diagram",
         "category": "VTEX IO Utilities",
         "shortTitle": "Create Diagram"
+      },
+      {
+        "command": "vtex-io-utilities-vscode.copyInstallCommand",
+        "title": "Copy install vtex apps command",
+        "category": "VTEX IO Utilities",
+        "shortTitle": "Copy Install Command"
+      },
+      {
+        "command": "vtex-io-utilities-vscode.copyDeployCommand",
+        "title": "Copy deploy vtex apps command",
+        "category": "VTEX IO Utilities",
+        "shortTitle": "Copy deploy Command"
+      }
+    ],
+    "submenus": [
+      {
+        "id": "vtex-io-utilities-vscode.submenu",
+        "label": "Vtex IO Utilities"
       }
     ],
     "menus": {
       "explorer/context": [
         {
+          "submenu": "vtex-io-utilities-vscode.submenu",
+          "when": "resourceScheme == 'file'",
+          "group": "navigation/@1"
+        }
+      ],
+      "vtex-io-utilities-vscode.submenu": [
+        {
           "command": "vtex-io-utilities-vscode.createDiagramFromContext",
           "when": "resourceScheme == 'file'",
-          "group": "navigation"
+          "group": "navigation/@1"
+        },
+        {
+          "command": "vtex-io-utilities-vscode.copyInstallCommand",
+          "when": "resourceScheme == 'file'",
+          "group": "navigation/@1"
+        },
+        {
+          "command": "vtex-io-utilities-vscode.copyDeployCommand",
+          "when": "resourceScheme == 'file'",
+          "group": "navigation/@1"
         }
       ]
     }
@@ -55,7 +90,8 @@
     "package": "vsce package --out dist",
     "watch": "webpack --watch",
     "lint": "eslint src --ext ts",
-    "prepare": "npx husky"
+    "prepare": "npx husky",
+    "postrelease": "npm run build"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.5.0",
@@ -85,5 +121,8 @@
   },
   "files": [
     "src/diagram.html"
-  ]
+  ],
+  "dependencies": {
+    "date-fns": "^4.1.0"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -39,13 +39,13 @@
       },
       {
         "command": "vtex-io-utilities-vscode.copyInstallCommand",
-        "title": "Copy install vtex apps command",
+        "title": "Copy install VTEX apps command",
         "category": "VTEX IO Utilities",
         "shortTitle": "Copy Install Command"
       },
       {
         "command": "vtex-io-utilities-vscode.copyDeployCommand",
-        "title": "Copy deploy vtex apps command",
+        "title": "Copy deploy VTEX apps command",
         "category": "VTEX IO Utilities",
         "shortTitle": "Copy deploy Command"
       }

--- a/package.json
+++ b/package.json
@@ -50,8 +50,9 @@
   },
   "scripts": {
     "publish": "npm run build && vsce publish",
-    "build": "npm run compile && vsce package",
+    "build": "npm run compile && npm run package",
     "compile": "webpack",
+    "package": "vsce package --out dist",
     "watch": "webpack --watch",
     "lint": "eslint src --ext ts",
     "prepare": "npx husky"

--- a/src/commands/copyVtexCommand.ts
+++ b/src/commands/copyVtexCommand.ts
@@ -1,0 +1,9 @@
+import * as vscode from "vscode";
+import { getAppsCommand } from "../shared";
+
+export async function copyVtexCommand(
+  command: string,
+  contextPaths?: string[]
+) {
+  getAppsCommand(command, contextPaths);
+}

--- a/src/commands/createDiagram.ts
+++ b/src/commands/createDiagram.ts
@@ -1,0 +1,22 @@
+import * as vscode from "vscode";
+import { createGraph } from "../shared";
+import { getWebviewContent } from "../shared/utils/createDiagram/render";
+
+export async function createDiagram(
+  context: vscode.ExtensionContext,
+  contextPaths?: string[]
+) {
+  let graphDirection = "TB";
+  const graph = await createGraph(graphDirection, contextPaths);
+
+  const panel = vscode.window.createWebviewPanel(
+    "diagramWebview",
+    "VTEX IO Diagram",
+    vscode.ViewColumn.One,
+    {
+      enableScripts: true,
+    }
+  );
+
+  panel.webview.html = getWebviewContent(context, graph, contextPaths);
+}

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,3 +1,2 @@
 export * from './copyVtexCommand';
 export * from './createDiagram';
-export * from './workspace';

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,0 +1,11 @@
+export const COMMAND_KEYS = {
+  CreateDiagram: "vtex-io-utilities-vscode.createDiagram",
+  CreateDiagramFromContext: "vtex-io-utilities-vscode.createDiagramFromContext",
+  CopyInstallCommand: "vtex-io-utilities-vscode.copyInstallCommand",
+  CopyDeployCommand: "vtex-io-utilities-vscode.copyDeployCommand",
+};
+
+export const VTEX_COMMANDS = {
+  Install: "vtex install",
+  Deploy: "vtex deploy",
+};

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,28 +1,50 @@
 import * as vscode from "vscode";
-import { createDiagram } from "./shared";
+import * as commands from "./commands";
+import { COMMAND_KEYS, VTEX_COMMANDS } from "./constants";
+import { Logger } from "./shared";
 
 export function activate(context: vscode.ExtensionContext) {
   registerCommands(context);
 }
 
 function registerCommands(context: vscode.ExtensionContext) {
-  // Registrar el comando para la paleta de comandos
-  let disposable = vscode.commands.registerCommand(
-    "vtex-io-utilities-vscode.createDiagram",
+  const createDiagram = vscode.commands.registerCommand(
+    COMMAND_KEYS.CreateDiagram,
     async () => {
-      await createDiagram(context);
+      await commands.createDiagram(context);
     }
   );
 
-  // Registrar el comando para el menú contextual
-  let disposableContext = vscode.commands.registerCommand(
-    "vtex-io-utilities-vscode.createDiagramFromContext",
+  const createDiagramContext = vscode.commands.registerCommand(
+    COMMAND_KEYS.CreateDiagramFromContext,
     async (uri: vscode.Uri, uris: vscode.Uri[]) => {
       const paths = uris.length ? uris.map((u) => u.fsPath) : [uri.fsPath];
-      await createDiagram(context, paths);
+      await commands.createDiagram(context, paths);
     }
   );
 
-  context.subscriptions.push(disposable);
-  context.subscriptions.push(disposableContext);
+  const copyInstallCommand = vscode.commands.registerCommand(
+    COMMAND_KEYS.CopyInstallCommand,
+    async (uri: vscode.Uri, uris: vscode.Uri[]) => {
+      const paths = uris.length ? uris.map((u) => u.fsPath) : [uri.fsPath];
+      await commands.copyVtexCommand(VTEX_COMMANDS.Install, paths);
+    }
+  );
+
+  const copyDeployCommand = vscode.commands.registerCommand(
+    COMMAND_KEYS.CopyDeployCommand,
+    async (uri: vscode.Uri, uris: vscode.Uri[]) => {
+      const paths = uris.length ? uris.map((u) => u.fsPath) : [uri.fsPath];
+      await commands.copyVtexCommand(VTEX_COMMANDS.Deploy, paths);
+    }
+  );
+
+  context.subscriptions.push(
+    createDiagram,
+    createDiagramContext,
+    copyInstallCommand,
+    copyDeployCommand
+  );
+
+  Logger.info("VTEX IO Utilities is now active!");
 }

--- a/src/shared/helpers/index.ts
+++ b/src/shared/helpers/index.ts
@@ -1,0 +1,1 @@
+export * from './logger';

--- a/src/shared/helpers/logger.ts
+++ b/src/shared/helpers/logger.ts
@@ -1,0 +1,40 @@
+import { OutputChannel, window } from "vscode";
+import { format } from "date-fns";
+
+export class Logger {
+  private static instance: Logger;
+  public static channel: OutputChannel | null = null;
+
+  private constructor() {
+    const displayName = "VTEX IO Utilities";
+    Logger.channel = window.createOutputChannel(displayName);
+  }
+
+  public static getInstance(): Logger {
+    if (!Logger.instance) {
+      Logger.instance = new Logger();
+    }
+    return Logger.instance;
+  }
+
+  public static info(
+    message: string,
+    type: "INFO" | "WARNING" | "ERROR" = "INFO"
+  ): void {
+    if (!Logger.channel) {
+      Logger.getInstance();
+    }
+
+    Logger.channel?.appendLine(
+      `["${type}" - ${format(new Date(), "HH:MM:ss")}]  ${message}`
+    );
+  }
+
+  public static warning(message: string): void {
+    Logger.info(message, "WARNING");
+  }
+
+  public static error(message: string): void {
+    Logger.info(message, "ERROR");
+  }
+}

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -1,2 +1,3 @@
-export * from "./models";
-export * from "./utils";
+export * from './helpers';
+export * from './models';
+export * from './utils';

--- a/src/shared/models.ts
+++ b/src/shared/models.ts
@@ -1,6 +1,7 @@
 export interface ManifestContent {
   dependencies: { [key: string]: string };
   vendor: string;
+  version: string;
   name: string;
 }
 

--- a/src/shared/utils/copyVtexCommand/getAppsCommand.ts
+++ b/src/shared/utils/copyVtexCommand/getAppsCommand.ts
@@ -1,0 +1,43 @@
+import { processFolders, readWorkspaceFolders } from "../workspace";
+import * as vscode from "vscode";
+
+export const getAppsCommand = async (
+  command: string,
+  contextPaths?: string[]
+) => {
+  let appsCommand: string = "";
+
+  const { foldersToRead, manifestContent } = await readWorkspaceFolders(
+    contextPaths,
+    false
+  );
+
+  if (foldersToRead.length) {
+    await processFolders(foldersToRead, manifestContent);
+    manifestContent.forEach((manifestData, index) => {
+      appsCommand += `${command} ${manifestData.vendor}.${manifestData.name}@${
+        manifestData.version
+      } ${index === manifestContent.length - 1 ? "" : "&& "}`;
+    });
+  }
+
+  if (appsCommand === "") {
+    vscode.window.showErrorMessage("No apps found in the selection.");
+    return null;
+  }
+
+  vscode.window
+    .showInformationMessage(
+      "VTEX IO command copied to clipboard.",
+      "Run in terminal"
+    )
+    .then((value) => {
+      if (value === "Run in terminal") {
+        vscode.commands.executeCommand("workbench.action.terminal.new");
+        vscode.env.clipboard.writeText(appsCommand);
+        vscode.commands.executeCommand("workbench.action.terminal.paste");
+      }
+    });
+  vscode.env.clipboard.writeText(appsCommand);
+  return appsCommand;
+};

--- a/src/shared/utils/copyVtexCommand/index.ts
+++ b/src/shared/utils/copyVtexCommand/index.ts
@@ -1,0 +1,1 @@
+export * from './getAppsCommand';

--- a/src/shared/utils/createDiagram/render.ts
+++ b/src/shared/utils/createDiagram/render.ts
@@ -7,7 +7,6 @@ export function getWebviewContent(
   graph: string | null,
   selectedFolders?: string[]
 ): string {
-  console.log("graph", graph);
   if (!graph || graph === "") {
     return `<h1>No dependencies found</h1>
     <h2>To visualize the dependency diagram:</h2>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1181,6 +1181,11 @@ dargs@^8.0.0:
   resolved "https://registry.npmjs.org/dargs/-/dargs-8.1.0.tgz"
   integrity sha512-wAV9QHOsNbwnWdNW2FYvE1P56wtgSbM+3SZcdGiWQILwVjACCXDCI3Ai8QlCjMDB8YK5zySiXZYBiwGmNY3lnw==
 
+date-fns@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-4.1.0.tgz#64b3d83fff5aa80438f5b1a633c2e83b8a1c2d14"
+  integrity sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==
+
 debug@4, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.3.5:
   version "4.3.7"
   resolved "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz"


### PR DESCRIPTION
#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

Se realizó la creación del menú contextual que permite tener ahora dos comandos nuevos los cuales permiten copiar al portapapeles o a la terminal la lista de apps a desplegar o instalar

![image](https://github.com/user-attachments/assets/94b47513-11cf-4403-9f47-ab20e8de24c9)

![image](https://github.com/user-attachments/assets/9c1d60e1-57d1-4500-bfa3-5f60754ce38a)

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExNTl0Nm50MWY0cXZmdmR4NjgwYTFweWswa2dscGRvZDAxdnpscjY2YyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/HQ1ogU9NXfCqVJWhgU/giphy.gif)
